### PR TITLE
Perf/grpc batching and concurrency

### DIFF
--- a/api/src/grpc_server.py
+++ b/api/src/grpc_server.py
@@ -10,7 +10,7 @@ import grpc
 import time
 import sys
 import os
-from threading import Thread, Lock
+from threading import Condition, Thread, Lock
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 # Add parent directory to path for absolute imports
@@ -34,6 +34,9 @@ logger = logging.getLogger(__name__)
 # Global variables for clients
 correction_multi_client = None
 client_lock = Lock()
+client_condition = Condition(client_lock)
+_client_inflight = {}
+_model_generation = 0
 
 def initialize_clients(max_retries: int = 5, retry_delay: int = 10):
     """
@@ -78,6 +81,65 @@ def initialize_clients(max_retries: int = 5, retry_delay: int = 10):
                 logger.critical("All client initialization attempts failed")
                 raise
 
+def invalidate_model_result_caches():
+    """Discard grammar results produced by the previously active client."""
+    process_cache_store.clear()
+    match_cache_store.clear()
+    match_anylized_cache_store.clear()
+
+
+def _acquire_client():
+    """Return a client lease that remains valid until ``_release_client``."""
+    with client_condition:
+        if correction_multi_client is None:
+            raise RuntimeError("Grammar clients have not been initialized")
+        client = correction_multi_client
+        client_id = id(client)
+        _client_inflight[client_id] = _client_inflight.get(client_id, 0) + 1
+        return client, _model_generation
+
+
+def _release_client(client):
+    with client_condition:
+        client_id = id(client)
+        remaining = _client_inflight[client_id] - 1
+        if remaining:
+            _client_inflight[client_id] = remaining
+        else:
+            del _client_inflight[client_id]
+            client_condition.notify_all()
+
+
+def _retire_client(client):
+    """Close an old client only after requests holding its lease have finished."""
+    if client is None:
+        return
+
+    with client_condition:
+        while _client_inflight.get(id(client), 0):
+            client_condition.wait()
+
+    close = getattr(client, "close", None)
+    if close:
+        close()
+
+
+def activate_client(new_client):
+    """Atomically make a warmed client current and retire its predecessor."""
+    global correction_multi_client, _model_generation
+
+    with client_condition:
+        old_client = correction_multi_client
+        correction_multi_client = new_client
+        _model_generation += 1
+        logger.info("Clients reloaded successfully")
+
+    # Generation-qualified keys prevent an old in-flight request from making
+    # its result visible to requests using the newly activated client.
+    invalidate_model_result_caches()
+    _retire_client(old_client)
+
+
 def reload_clients_periodically(reload_interval: int = 3600):
     """
     Periodically reload clients in a background thread.
@@ -85,8 +147,6 @@ def reload_clients_periodically(reload_interval: int = 3600):
     Args:
         reload_interval: Interval in seconds between reloads (default: 3600 = 1 hour)
     """
-    global correction_multi_client
-    
     while True:
         try:
             time.sleep(reload_interval)
@@ -94,27 +154,11 @@ def reload_clients_periodically(reload_interval: int = 3600):
             
             new_client = initialize_clients()
             
-            with client_lock:
-                old_client = correction_multi_client
-                correction_multi_client = new_client
-                logger.info("Clients reloaded successfully")
-                
-                # Allow some time for in-flight requests to complete with old client
-                time.sleep(5)
-                del old_client
+            activate_client(new_client)
                 
         except Exception as e:
             logger.error(f"Failed to reload clients: {str(e)}", exc_info=True)
             logger.info("Continuing with existing clients")
-
-# Model initialization - load from config file with retry
-correction_multi_client = initialize_clients()
-
-# Start background thread for periodic client reloading
-reload_interval = int(os.getenv('GRAMMARED_LANGUAGE__CLIENT_RELOAD_INTERVAL', '3600'))
-reload_thread = Thread(target=reload_clients_periodically, args=(reload_interval,), daemon=True)
-reload_thread.start()
-logger.info(f"Started client reload thread (interval: {reload_interval}s)")
 
 # # Initialize ERRANT Grammar Correction Extractor
 # errant_extractor = ErrantGrammarCorrectionExtractor(language='en', min_length=1)
@@ -124,6 +168,28 @@ analyze_cache_store = SimpleCacheStore(cache_size)
 process_cache_store = SimpleCacheStore(cache_size)
 match_cache_store = SimpleCacheStore(cache_size)
 match_anylized_cache_store = SimpleCacheStore(cache_size)
+
+
+def _model_cache_key(generation, text):
+    return generation, text
+
+
+def initialize_runtime():
+    """Initialize the first client and start periodic reloads exactly once."""
+    global correction_multi_client
+    with client_lock:
+        already_initialized = correction_multi_client is not None
+    if already_initialized:
+        return
+
+    new_client = initialize_clients()
+    activate_client(new_client)
+    reload_interval = int(os.getenv('GRAMMARED_LANGUAGE__CLIENT_RELOAD_INTERVAL', '3600'))
+    reload_thread = Thread(
+        target=reload_clients_periodically, args=(reload_interval,), daemon=True
+    )
+    reload_thread.start()
+    logger.info(f"Started client reload thread (interval: {reload_interval}s)")
 
 # Health check state
 service_healthy = False
@@ -273,25 +339,39 @@ class ProcessingServerServicer(ml_server_pb2_grpc.ProcessingServerServicer):
         try:
             logger.info(f"Process request: {len(request.sentences)} sentences, language={request.options.language}")
             
-            raw_matches = []
-            matches_by_sentence = []
-            
-            for sentence in request.sentences:
-                text = sentence.text
-                if process_cache_store.contains(text):
-                    result = process_cache_store.get(text)
-                else:
-                    # Predict using both models, merge and enrich, then cache
-                    with client_lock:
-                        result = correction_multi_client.predict_with_merge(text)
-                    process_cache_store.add(text, result)
+            client, generation = _acquire_client()
+            try:
+                results = [None] * len(request.sentences)
+                missing_indices = {}
+                missing_texts = []
+                for index, sentence in enumerate(request.sentences):
+                    text = sentence.text
+                    cache_key = _model_cache_key(generation, text)
+                    if process_cache_store.contains(cache_key):
+                        results[index] = process_cache_store.get(cache_key)
+                    elif text not in missing_indices:
+                        missing_indices[text] = [index]
+                        missing_texts.append(text)
+                    else:
+                        missing_indices[text].append(index)
 
-                # Convert matches to ml_server format
-                sentence_matches = ml_server_pb2.MatchList(
-                    matches=[pydantic_match_to_ml_match(m) for m in result.matches]
-                )
-                matches_by_sentence.append(sentence_matches)
-                raw_matches.extend(sentence_matches.matches)
+                if missing_texts:
+                    task_results = client.predict_with_merge(missing_texts)
+                    for text, result in zip(missing_texts, task_results):
+                        # A reload may have advanced the generation while this
+                        # lease was running. Such entries cannot be read by new
+                        # requests, but can temporarily occupy cache capacity.
+                        process_cache_store.add(_model_cache_key(generation, text), result)
+                        for index in missing_indices[text]:
+                            results[index] = result
+
+                raw_matches = []
+                for result in results:
+                    raw_matches.extend(
+                        pydantic_match_to_ml_match(match) for match in result.matches
+                    )
+            finally:
+                _release_client(client)
             
             return ml_server_pb2.ProcessResponse(
                 rawMatches=raw_matches,
@@ -321,28 +401,33 @@ class MLServerServicer(ml_server_pb2_grpc.MLServerServicer):
         """
         try:
             logger.info(f"Match request: {len(request.sentences)} sentences")
-            
-            results = {i:None for i in range(len(request.sentences))}
-            match_tasks = [] # (idx, text)
-            for i, analyzed_sentence in enumerate(request.sentences):
-                if match_cache_store.contains(analyzed_sentence):
-                    results[i] = match_cache_store.get(analyzed_sentence)
-                else:
-                    match_tasks.append((i, analyzed_sentence))
 
-            with client_lock:
-                task_results = correction_multi_client.predict_with_merge([s for _, s in match_tasks])
-            for (idx, _), result in zip(match_tasks, task_results):
-                results[idx] = result
-                match_cache_store.add(request.sentences[idx], result)
-            
-            sentence_matches = []
-            for i in range(len(request.sentences)):
-                enriched_result = results[i]
-                matches = ml_server_pb2.MatchList(
-                    matches=[pydantic_match_to_ml_match(m) for m in enriched_result.matches]
-                )
-                sentence_matches.append(matches)
+            client, generation = _acquire_client()
+            try:
+                results = {i: None for i in range(len(request.sentences))}
+                match_tasks = []  # (idx, text)
+                for i, analyzed_sentence in enumerate(request.sentences):
+                    cache_key = _model_cache_key(generation, analyzed_sentence)
+                    if match_cache_store.contains(cache_key):
+                        results[i] = match_cache_store.get(cache_key)
+                    else:
+                        match_tasks.append((i, analyzed_sentence))
+
+                if match_tasks:
+                    task_results = client.predict_with_merge([s for _, s in match_tasks])
+                    for (idx, text), result in zip(match_tasks, task_results):
+                        results[idx] = result
+                        match_cache_store.add(_model_cache_key(generation, text), result)
+
+                sentence_matches = []
+                for i in range(len(request.sentences)):
+                    enriched_result = results[i]
+                    matches = ml_server_pb2.MatchList(
+                        matches=[pydantic_match_to_ml_match(m) for m in enriched_result.matches]
+                    )
+                    sentence_matches.append(matches)
+            finally:
+                _release_client(client)
             return ml_server_pb2.MatchResponse(sentenceMatches=sentence_matches)
             
         except Exception as e:
@@ -364,30 +449,35 @@ class MLServerServicer(ml_server_pb2_grpc.MLServerServicer):
         """
         try:
             logger.info(f"MatchAnalyzed request: {len(request.sentences)} analyzed sentences")
-            
-            results = {i:None for i in range(len(request.sentences))}
-            match_tasks = [] # (idx, text)
-            for i, analyzed_sentence in enumerate(request.sentences):
-                # Serialize protobuf to string for hashing
-                cache_key = analyzed_sentence.text
-                if match_anylized_cache_store.contains(cache_key):
-                    results[i] = match_anylized_cache_store.get(cache_key)
-                else:
-                    match_tasks.append((i, analyzed_sentence))
 
-            with client_lock:
-                task_results = correction_multi_client.predict_with_merge([s.text for _, s in match_tasks])
-            for (idx, analyzed_sentence), result in zip(match_tasks, task_results):
-                results[idx] = result
-                match_anylized_cache_store.add(analyzed_sentence.text, result)
-            
-            sentence_matches = []
-            for i in range(len(request.sentences)):
-                enriched_result = results[i]
-                matches = ml_server_pb2.MatchList(
-                    matches=[pydantic_match_to_ml_match(m) for m in enriched_result.matches]
-                )
-                sentence_matches.append(matches)
+            client, generation = _acquire_client()
+            try:
+                results = {i: None for i in range(len(request.sentences))}
+                match_tasks = []  # (idx, analyzed sentence)
+                for i, analyzed_sentence in enumerate(request.sentences):
+                    cache_key = _model_cache_key(generation, analyzed_sentence.text)
+                    if match_anylized_cache_store.contains(cache_key):
+                        results[i] = match_anylized_cache_store.get(cache_key)
+                    else:
+                        match_tasks.append((i, analyzed_sentence))
+
+                if match_tasks:
+                    task_results = client.predict_with_merge([s.text for _, s in match_tasks])
+                    for (idx, analyzed_sentence), result in zip(match_tasks, task_results):
+                        results[idx] = result
+                        match_anylized_cache_store.add(
+                            _model_cache_key(generation, analyzed_sentence.text), result
+                        )
+
+                sentence_matches = []
+                for i in range(len(request.sentences)):
+                    enriched_result = results[i]
+                    matches = ml_server_pb2.MatchList(
+                        matches=[pydantic_match_to_ml_match(m) for m in enriched_result.matches]
+                    )
+                    sentence_matches.append(matches)
+            finally:
+                _release_client(client)
             return ml_server_pb2.MatchResponse(sentenceMatches=sentence_matches)
             
         except Exception as e:
@@ -407,6 +497,8 @@ def serve(host: str = "0.0.0.0", port: int = 50051, health_port: int = 50052):
         health_port: Port for HTTP health check endpoint
     """
     global service_healthy
+
+    initialize_runtime()
     
     # Create gRPC server
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=50))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - LOG_VERBOSE=0
       - TRANSFORMERS_CACHE=/cache
       - HF_HOME=/cache
+      # HUGGING_FACE_TOKEN is supplied by .env
+      - HF_TOKEN=${HUGGING_FACE_TOKEN}
     ports:
       - "8000:8000"  # HTTP
       - "8001:8001"  # gRPC
@@ -22,7 +24,6 @@ services:
     volumes:
       - ./config/triton:/config:ro
       - triton-cache:/cache  # HuggingFace model cache
-      - ./hf_token:/cache/token  # HuggingFace token for private models
       - ./model_config.yaml:/model_config.yaml:ro  # Model configuration
       # - ./triton_server/example_model_repository:/models:ro  # Example models
     # shm_size: '1gb'
@@ -58,11 +59,12 @@ services:
       - ./model_config.yaml:/model_config.yaml:ro  # Model configuration
       - ./data:/data
       # - triton-cache:/cache  # HuggingFace model cache
-      - ./hf_token:/cache/token  # HuggingFace token for private models
     environment:
       # - GRRAMMARED_LANGUAGE__API_PORT=50051
       - LOG_LEVEL=INFO
       - GRAMMARED_LANGUAGE__MODEL_CONFIG_PATH=/model_config.yaml
+      # HUGGING_FACE_TOKEN is supplied by .env for tokenizer/model downloads.
+      - HF_TOKEN=${HUGGING_FACE_TOKEN}
       # - TRANSFORMERS_CACHE=/cache
       # - HF_HOME=/cache
     depends_on:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -55,14 +55,13 @@ COPY api/src/ /src/
 
 # Create non-root user for security
 RUN useradd -m -u 1000 apiuser && \
+    mkdir -p /src/data && \
     chown -R apiuser:apiuser /src
 
 USER apiuser
 
 # Change working directory to root to avoid import conflicts with /grammared_language
 WORKDIR /src
-
-COPY data/verb-form-vocab.txt /src/data/verb-form-vocab.txt
 
 # Expose API port
 EXPOSE 50051 50052

--- a/docker/triton/build_repo.py
+++ b/docker/triton/build_repo.py
@@ -16,32 +16,12 @@ logging.basicConfig(level=logging.DEBUG)
 """
 
 
-def is_non_empty_dir(directory_path):
-    """
-    Checks if the directory exists, is a directory, and is not empty.
-    """
-    if not os.path.isdir(directory_path):
-        return False
-    
-    # Check if directory is empty using os.scandir()
-    try:
-        with os.scandir(directory_path) as it:
-            return any(it) # Returns True if there is any entry, False otherwise
-    except OSError:
-        # Handle potential permission errors or other OS issues
-        return False
-    
-
 def build_triton_model_repo():
-    if is_non_empty_dir(MODEL_REPO_FOLDER):
-        logger.info(f"Model repository folder '{MODEL_REPO_FOLDER}' already exists and is not empty. Skipping build.")
-        return
     model_repo_path = os.environ.get("GRAMMARED_LANGUAGE__MODEL_REPO_FOLDER", MODEL_REPO_FOLDER)
     config = get_config()
-    # Build the model repository
     Path(model_repo_path).mkdir(parents=True, exist_ok=True)
     builder = TritonRepoBuilder()
-    builder.build_model_repo(
+    builder.reconcile_model_repo(
         repo_folder=model_repo_path,
         config=config
     )

--- a/grammared_language/api/util.py
+++ b/grammared_language/api/util.py
@@ -28,3 +28,8 @@ class SimpleCacheStore:
         with self._lock:
             self.store.move_to_end(text)
             return self.store.get(text)
+
+    def clear(self):
+        """Remove all entries from the cache."""
+        with self._lock:
+            self.store.clear()

--- a/grammared_language/clients/async_multi_client.py
+++ b/grammared_language/clients/async_multi_client.py
@@ -104,13 +104,11 @@ class AsyncMultiClient:
         """
         results = await self._predict_async(text)
         
-        if not results:
-            return LanguageToolRemoteResult(
-                language="English",
-                languageCode="en-US",
-                matches=[]
-            )
-        
+        return self._merge_results(results)
+
+    @staticmethod
+    def _merge_results(results: List[LanguageToolRemoteResult]) -> LanguageToolRemoteResult:
+        """Merge client results while preserving single-input merge semantics."""
         # Merge matches from all results
         merged_matches = []
         seen_replacements = set()
@@ -149,24 +147,10 @@ class AsyncMultiClient:
         Returns:
             List of merged LanguageToolRemoteResult for each text
         """
-        tasks = [self._predict_with_merge_async(text) for text in texts]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        
-        # Filter out exceptions and return valid results
-        valid_results = []
-        for i, result in enumerate(results):
-            if isinstance(result, Exception):
-                print(f"Text {i} failed with error: {result}")
-                # Return empty result for failed text
-                valid_results.append(LanguageToolRemoteResult(
-                    language="English",
-                    languageCode="en-US",
-                    matches=[]
-                ))
-            else:
-                valid_results.append(result)
-        
-        return valid_results
+        # Keep inference model-oriented: each client receives the complete
+        # batch once, then merge that client's result with the others per text.
+        results_by_text = await self._predict_batch_async(texts)
+        return [self._merge_results(results) for results in results_by_text]
     
     def predict(self, text: str) -> List[LanguageToolRemoteResult]:
         """

--- a/grammared_language/clients/base_client.py
+++ b/grammared_language/clients/base_client.py
@@ -28,32 +28,37 @@ class BaseClient:
     def _output_postprocess(self, original: str, pred: LanguageToolRemoteResult, **kwargs) -> LanguageToolRemoteResult:
         return pred
 
-    @lru_cache(maxsize=int(os.getenv('GRAMMARED_LANGUAGE__GRPC_SERVER_CACHE_SIZE', '100000')))
     def predict(self, text: str|list[str]) -> LanguageToolRemoteResult|list[LanguageToolRemoteResult]:
-        single = True
+        """Predict one text or an uncached model-oriented batch of texts."""
         if isinstance(text, list):
-            single = False
+            return self._predict_batch(text)
+        return self._predict_single(text)
 
-        if single:
-            _text = self._preprocess(text)
-        else:
-            _text = [self._preprocess(t) for t in text]
-        corrected_text: str|list[str] = self._predict(_text)
+    @lru_cache(maxsize=int(os.getenv('GRAMMARED_LANGUAGE__GRPC_SERVER_CACHE_SIZE', '100000')))
+    def _predict_single(self, text: str) -> LanguageToolRemoteResult:
+        """Predict and cache a single hashable input text."""
+        _text = self._preprocess(text)
+        corrected_text = self._predict(_text)
+        pred = self._pred_postprocess(text, corrected_text)
+        return self._output_postprocess(text, pred)
 
-        output = None
-        if single:
-            pred: LanguageToolRemoteResult = self._pred_postprocess(text, corrected_text)
-            output = self._output_postprocess(text, pred)
-        else:
-            pred = [
-                self._pred_postprocess(orig, corr)
-                for orig, corr in zip(text, corrected_text)
-            ]
-            output = [
-                self._output_postprocess(orig, p)
-                for orig, p in zip(text, pred)
-            ]
-        return output
+    def _predict_batch(self, texts: list[str]) -> list[LanguageToolRemoteResult]:
+        """Predict a batch without caching the unhashable list input."""
+        _texts = [self._preprocess(text) for text in texts]
+        corrected_texts = self._predict(_texts)
+        if len(corrected_texts) != len(texts):
+            raise RuntimeError(
+                f"Batch prediction returned {len(corrected_texts)} outputs "
+                f"for {len(texts)} inputs"
+            )
+        pred = [
+            self._pred_postprocess(original, corrected)
+            for original, corrected in zip(texts, corrected_texts)
+        ]
+        return [
+            self._output_postprocess(original, result)
+            for original, result in zip(texts, pred)
+        ]
 
     def __call__(self, text: str) -> LanguageToolRemoteResult:
         return self.predict(text)

--- a/grammared_language/clients/base_client.py
+++ b/grammared_language/clients/base_client.py
@@ -1,13 +1,23 @@
 import os
+from collections import OrderedDict
+from threading import RLock
+from typing import Optional
+
 from grammared_language.language_tool.output_models import LanguageToolRemoteResult
 from grammared_language.utils.errant_grammar_correction_extractor import ErrantGrammarCorrectionExtractor
-from functools import lru_cache
 
 class BaseClient:
     def __init__(self, *args, **kwargs):
         self.rule_id = kwargs.get("rule_id", "GrammaredLanguage")
         print(f"Initialized BaseClient with rule_id: {self.rule_id}")
         self.correction_extractor = ErrantGrammarCorrectionExtractor(rule_id=self.rule_id)
+        self._cache_size = int(
+            os.getenv("GRAMMARED_LANGUAGE__GRPC_SERVER_CACHE_SIZE", "100000")
+        )
+        self._sentence_cache: OrderedDict[str, LanguageToolRemoteResult] = OrderedDict()
+        self._cache_lock = RLock()
+        self._cache_hits = 0
+        self._cache_misses = 0
     
     def _preprocess(self, text: str) -> str:
         return text
@@ -29,36 +39,95 @@ class BaseClient:
         return pred
 
     def predict(self, text: str|list[str]) -> LanguageToolRemoteResult|list[LanguageToolRemoteResult]:
-        """Predict one text or an uncached model-oriented batch of texts."""
+        """Predict one text or a model-oriented batch using the sentence cache."""
         if isinstance(text, list):
             return self._predict_batch(text)
         return self._predict_single(text)
 
-    @lru_cache(maxsize=int(os.getenv('GRAMMARED_LANGUAGE__GRPC_SERVER_CACHE_SIZE', '100000')))
     def _predict_single(self, text: str) -> LanguageToolRemoteResult:
-        """Predict and cache a single hashable input text."""
+        """Predict one text, consulting and updating the shared sentence cache."""
+        cached = self._cache_get(text)
+        if cached is not None:
+            return cached
+
         _text = self._preprocess(text)
         corrected_text = self._predict(_text)
         pred = self._pred_postprocess(text, corrected_text)
-        return self._output_postprocess(text, pred)
+        result = self._output_postprocess(text, pred)
+        self._cache_put(text, result)
+        return result
 
     def _predict_batch(self, texts: list[str]) -> list[LanguageToolRemoteResult]:
-        """Predict a batch without caching the unhashable list input."""
-        _texts = [self._preprocess(text) for text in texts]
+        """Predict only unique cache misses in one model batch, preserving order."""
+        results: list[Optional[LanguageToolRemoteResult]] = [None] * len(texts)
+        misses: list[str] = []
+        miss_indexes: dict[str, list[int]] = {}
+
+        for index, text in enumerate(texts):
+            cached = self._cache_get(text)
+            if cached is not None:
+                results[index] = cached
+            elif text in miss_indexes:
+                # The first occurrence owns the model result for all duplicates.
+                miss_indexes[text].append(index)
+            else:
+                misses.append(text)
+                miss_indexes[text] = [index]
+
+        if not misses:
+            return [result for result in results if result is not None]
+
+        _texts = [self._preprocess(text) for text in misses]
         corrected_texts = self._predict(_texts)
-        if len(corrected_texts) != len(texts):
+        if len(corrected_texts) != len(misses):
             raise RuntimeError(
                 f"Batch prediction returned {len(corrected_texts)} outputs "
-                f"for {len(texts)} inputs"
+                f"for {len(misses)} inputs"
             )
-        pred = [
-            self._pred_postprocess(original, corrected)
-            for original, corrected in zip(texts, corrected_texts)
-        ]
-        return [
-            self._output_postprocess(original, result)
-            for original, result in zip(texts, pred)
-        ]
+
+        for text, corrected in zip(misses, corrected_texts):
+            pred = self._pred_postprocess(text, corrected)
+            result = self._output_postprocess(text, pred)
+            self._cache_put(text, result)
+            for index in miss_indexes[text]:
+                results[index] = result
+
+        return [result for result in results if result is not None]
+
+    def _cache_get(self, text: str) -> Optional[LanguageToolRemoteResult]:
+        """Get a sentence result and refresh its LRU position.
+
+        Results are intentionally returned by reference, matching the former
+        ``lru_cache`` behavior. Callers must treat them as immutable.
+        """
+        with self._cache_lock:
+            result = self._sentence_cache.get(text)
+            if result is None:
+                self._cache_misses += 1
+                return None
+            self._sentence_cache.move_to_end(text)
+            self._cache_hits += 1
+            return result
+
+    def _cache_put(self, text: str, result: LanguageToolRemoteResult) -> None:
+        """Store a result, evicting the least recently used entry if necessary."""
+        if self._cache_size <= 0:
+            return
+        with self._cache_lock:
+            self._sentence_cache[text] = result
+            self._sentence_cache.move_to_end(text)
+            while len(self._sentence_cache) > self._cache_size:
+                self._sentence_cache.popitem(last=False)
+
+    def cache_stats(self) -> dict[str, int]:
+        """Return lightweight cache metrics useful for diagnostics and benchmarks."""
+        with self._cache_lock:
+            return {
+                "hits": self._cache_hits,
+                "misses": self._cache_misses,
+                "size": len(self._sentence_cache),
+                "maxsize": self._cache_size,
+            }
 
     def __call__(self, text: str) -> LanguageToolRemoteResult:
         return self.predict(text)

--- a/grammared_language/clients/gector_client.py
+++ b/grammared_language/clients/gector_client.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+import tempfile
 from urllib.request import urlopen
 
 from .base_client import BaseClient
@@ -29,6 +31,70 @@ except ImportError:
     TRANSFORMERS_AVAILABLE = False
 
 OFFICIAL_VOCAB_URL = "https://github.com/grammarly/gector/raw/master/data/verb-form-vocab.txt"
+
+
+class VerbDictionaryError(ValueError):
+    """Raised when GECToR's verb-form vocabulary cannot be made usable."""
+
+
+def load_and_validate_verb_dict(verb_dict_file: Path):
+    """Load a vocabulary and reject empty or malformed parser output."""
+    if not verb_dict_file.is_file():
+        raise VerbDictionaryError("file is missing or is not a regular file")
+    if verb_dict_file.stat().st_size == 0:
+        raise VerbDictionaryError("file is empty")
+    try:
+        encode, decode = load_verb_dict(str(verb_dict_file))
+    except Exception as exc:
+        raise VerbDictionaryError(f"could not be parsed: {exc}") from exc
+    if not encode or not decode:
+        raise VerbDictionaryError("parsed to zero encode or decode entries")
+    return encode, decode
+
+
+def ensure_verb_dict(
+    verb_dict_path: str,
+    *,
+    auto_download: bool,
+    download_url: str = OFFICIAL_VOCAB_URL,
+):
+    """Return a validated verb dictionary, replacing invalid files atomically."""
+    verb_dict_file = Path(verb_dict_path)
+    existed = verb_dict_file.exists()
+    try:
+        return load_and_validate_verb_dict(verb_dict_file)
+    except VerbDictionaryError as validation_error:
+        validation_reason = str(validation_error)
+        if not auto_download:
+            raise FileNotFoundError(
+                f"GECToR verb vocabulary at '{verb_dict_file}' existed={existed} "
+                f"but is invalid: {validation_reason}. Automatic download is disabled."
+            ) from validation_error
+
+    verb_dict_file.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = None
+    try:
+        with urlopen(download_url) as response:
+            downloaded_content = response.read()
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=verb_dict_file.parent, delete=False,
+            prefix=f".{verb_dict_file.name}.", suffix=".tmp"
+        ) as temporary_file:
+            temporary_path = Path(temporary_file.name)
+            temporary_file.write(downloaded_content)
+        encode, decode = load_and_validate_verb_dict(temporary_path)
+        os.replace(temporary_path, verb_dict_file)
+        return encode, decode
+    except Exception as download_error:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise FileNotFoundError(
+            f"GECToR verb vocabulary at '{verb_dict_file}' existed={existed} and "
+            f"was invalid: {validation_reason}. Download from {download_url} failed: "
+            f"{download_error}"
+        ) from download_error
+
+
 class GectorClient(BaseClient):
     def __init__(
             self,
@@ -49,6 +115,10 @@ class GectorClient(BaseClient):
         if not TRANSFORMERS_AVAILABLE:
             raise ImportError("transformers package is required for GectorClient. Install it with: pip install transformers")
         
+        self.encode, self.decode = ensure_verb_dict(
+            verb_dict_path, auto_download=auto_download_official_vocab
+        )
+
         if triton_model_name is None:
             self.model = GECToR.from_pretrained(pretrained_model_name_or_path)
         else:
@@ -61,19 +131,6 @@ class GectorClient(BaseClient):
             )
 
         self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
-        verb_dict_file = Path(verb_dict_path)
-        if auto_download_official_vocab and not verb_dict_file.is_file():
-            verb_dict_file.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                with urlopen(OFFICIAL_VOCAB_URL) as response:
-                    verb_dict_file.write_bytes(response.read())
-            except Exception as exc:
-                raise FileNotFoundError(
-                    f"Failed to download verb vocab from {OFFICIAL_VOCAB_URL} to {verb_dict_file}"
-                ) from exc
-
-        self.encode, self.decode = load_verb_dict(verb_dict_path)
-
         self.pred_config = {
             'keep_confidence': kwargs.get('keep_confidence', 0),
             'min_error_prob': kwargs.get('min_error_prob', 0),

--- a/grammared_language/clients/text2text_base_client.py
+++ b/grammared_language/clients/text2text_base_client.py
@@ -118,11 +118,11 @@ class Text2TextBaseClient(BaseClient):
         Returns:
             Generated/corrected text from the model
         """
-        # Prepare input as numpy array with shape [1, 1] for batching
-        # First dimension is batch size, second is the string dimension
+        # Prepare input as a two-dimensional array: [batch_size, 1].  Triton's
+        # text-to-text backend reads each prompt as input_data[i][0].
         single = True
         if isinstance(text, list):
-            text_np = np.array([text], dtype=object)
+            text_np = np.asarray(text, dtype=object).reshape(-1, 1)
             single = False
         else:
             text_np = np.array([[text]], dtype=object)

--- a/grammared_language/triton/builder/repo_builder.py
+++ b/grammared_language/triton/builder/repo_builder.py
@@ -1,5 +1,7 @@
 # from .triton.triton_templates import
 import json
+import shutil
+import logging
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 import yaml
@@ -7,6 +9,8 @@ from grammared_language.utils .config_parser import BaseModelConfig, ModelsConfi
 from grammared_language.utils import config_parser
 
 DEFAULT_TEMPLATE_FOLDER = str(Path(__file__).parent / "triton_templates")
+GENERATED_MANIFEST_FILENAME = ".grammared-language-generated-models.json"
+logger = logging.getLogger(__name__)
 
 SUPPORTED_MODEL_TYPES = ("gector", "grammared_classifier", "coedit", "text2text")
 
@@ -68,6 +72,42 @@ class TritonRepoBuilder:
                     model_config=model_config,
                     repo_folder=repo_folder
             )
+
+    def reconcile_model_repo(self, repo_folder: str, config: ModelsConfig):
+        """Synchronize Grammared-owned model directories with ``config``.
+
+        The manifest means a pre-existing user directory is never removed.
+        Generated files are only rewritten when their rendered contents differ.
+        """
+        repo_path = Path(repo_folder)
+        repo_path.mkdir(parents=True, exist_ok=True)
+        manifest_path = repo_path / GENERATED_MANIFEST_FILENAME
+        previous_names = set()
+        if manifest_path.is_file():
+            try:
+                previous_names = set(json.loads(manifest_path.read_text()).get("models", []))
+            except (OSError, json.JSONDecodeError):
+                logger.warning("Ignoring invalid generated-model manifest: %s", manifest_path)
+
+        desired = {}
+        for logical_name, model_config in config.models.items():
+            if model_config.type not in SUPPORTED_MODEL_TYPES:
+                raise ValueError(f"Unsupported model type: {model_config.type}")
+            name = model_config.serving_config.triton_model_name or logical_name
+            if name in desired:
+                raise ValueError(f"Duplicate Triton model name: {name}")
+            desired[name] = model_config
+
+        for stale_name in previous_names - set(desired):
+            stale_path = repo_path / stale_name
+            if stale_path.is_dir() and stale_path.parent.resolve() == repo_path.resolve():
+                shutil.rmtree(stale_path)
+
+        for name, model_config in desired.items():
+            self._build_model_repo(name, model_config, str(repo_path))
+
+        manifest_contents = json.dumps({"models": sorted(desired)}, indent=2) + "\n"
+        self._write_if_changed(manifest_path, manifest_contents)
             
     def _build_model_repo(self, name:str, model_config:BaseModelConfig, repo_folder:str, model_version:int=1):
         model_type = model_config.type
@@ -93,8 +133,10 @@ class TritonRepoBuilder:
         model_file = self.jinja_env.get_template(template_files["model"]).render()
         Path(output_folder).mkdir(parents=True, exist_ok=True)
         Path(model_folder).mkdir(parents=True, exist_ok=True)
-        with open(output_folder / "config.pbtxt", "w") as f:
-            f.write(config_file)
+        self._write_if_changed(output_folder / "config.pbtxt", config_file)
+        self._write_if_changed(model_folder / "model.py", model_file)
 
-        with open(model_folder / "model.py", "w") as f:
-            f.write(model_file)
+    @staticmethod
+    def _write_if_changed(path: Path, contents: str):
+        if not path.is_file() or path.read_text() != contents:
+            path.write_text(contents)

--- a/grammared_language/triton/builder/repo_builder.py
+++ b/grammared_language/triton/builder/repo_builder.py
@@ -8,7 +8,7 @@ from grammared_language.utils import config_parser
 
 DEFAULT_TEMPLATE_FOLDER = str(Path(__file__).parent / "triton_templates")
 
-SUPPORTED_MODEL_TYPES = ("gector", "grammared_classifier", "coedit")
+SUPPORTED_MODEL_TYPES = ("gector", "grammared_classifier", "coedit", "text2text")
 
 TEMPLATE_FILES_BY_MODEL_TYPE = {
     "gector": {
@@ -22,7 +22,20 @@ TEMPLATE_FILES_BY_MODEL_TYPE = {
     "coedit": {
         "config": "text2text.config.pbtxt.jinja",
         "model": "text2text.model.py.jinja"
+    },
+    "text2text": {
+        "config": "text2text.config.pbtxt.jinja",
+        "model": "text2text.model.py.jinja"
     }
+}
+
+# These are legacy generated-config defaults, kept outside the templates so all
+# scheduling values supplied to a template have a single, explicit source.
+DEFAULT_QUEUE_DELAY_MICROSECONDS_BY_MODEL_TYPE = {
+    "gector": 350,
+    "coedit": 750,
+    "text2text": 750,
+    "grammared_classifier": 100,
 }
 
 class TritonRepoBuilder:
@@ -62,10 +75,19 @@ class TritonRepoBuilder:
         template_files = TEMPLATE_FILES_BY_MODEL_TYPE[model_type]
         output_folder = Path(repo_folder) / name
         model_folder = output_folder / str(model_version)
+        serving_config = model_config.serving_config
+        max_queue_delay_microseconds = serving_config.max_queue_delay_microseconds
+        if max_queue_delay_microseconds is None:
+            max_queue_delay_microseconds = DEFAULT_QUEUE_DELAY_MICROSECONDS_BY_MODEL_TYPE[
+                model_type
+            ]
         config_file = self.jinja_env.get_template(template_files["config"]).render({
             "model_name": name,
             "pretrained_model_name_or_path": pretrained_model_name_or_path,
             "json_model_config": json.dumps(model_config.model_dump_json())[1:-1],
+            "max_batch_size": serving_config.max_batch_size,
+            "preferred_batch_sizes": serving_config.preferred_batch_sizes,
+            "max_queue_delay_microseconds": max_queue_delay_microseconds,
         })
 
         model_file = self.jinja_env.get_template(template_files["model"]).render()

--- a/grammared_language/triton/builder/triton_templates/gector.config.pbtxt.jinja
+++ b/grammared_language/triton/builder/triton_templates/gector.config.pbtxt.jinja
@@ -1,6 +1,6 @@
 name: "{{ model_name }}"
 backend: "python"
-max_batch_size: 8
+max_batch_size: {{ max_batch_size }}
 
 # Hugging face model path. Parameters must follow this
 parameters: {
@@ -58,8 +58,10 @@ parameters: {
 
 # Dynamic batching for better throughput
 dynamic_batching {
-  preferred_batch_size: [1, 2, 4, 8]
-  max_queue_delay_microseconds: 350
+{% if preferred_batch_sizes %}
+  preferred_batch_size: [{{ preferred_batch_sizes | join(', ') }}]
+{% endif %}
+  max_queue_delay_microseconds: {{ max_queue_delay_microseconds }}
 }
 
 # Model versioning

--- a/grammared_language/triton/builder/triton_templates/grammared_classifier.config.pbtxt.jinja
+++ b/grammared_language/triton/builder/triton_templates/grammared_classifier.config.pbtxt.jinja
@@ -1,6 +1,6 @@
 name: "{{ model_name }}"
 backend: "python"
-max_batch_size: 8
+max_batch_size: {{ max_batch_size }}
 
 # Hugging face model path. Parameters must follow this
 # key/value structure
@@ -49,8 +49,10 @@ parameters: {
 
 # Dynamic batching for better throughput
 dynamic_batching {
-  preferred_batch_size: [1, 2, 4, 8]
-  max_queue_delay_microseconds: 100
+{% if preferred_batch_sizes %}
+  preferred_batch_size: [{{ preferred_batch_sizes | join(', ') }}]
+{% endif %}
+  max_queue_delay_microseconds: {{ max_queue_delay_microseconds }}
 }
 
 # Model versioning

--- a/grammared_language/triton/builder/triton_templates/text2text.config.pbtxt.jinja
+++ b/grammared_language/triton/builder/triton_templates/text2text.config.pbtxt.jinja
@@ -1,6 +1,6 @@
 name: "{{ model_name }}"
 backend: "python"
-max_batch_size: 8
+max_batch_size: {{ max_batch_size }}
 
 # Hugging face model path. Parameters must follow this
 # key/value structure
@@ -53,6 +53,8 @@ parameters: {
 
 # Dynamic batching for better throughput
 dynamic_batching {
-  preferred_batch_size: [1, 2, 4, 8]
-  max_queue_delay_microseconds: 750
+{% if preferred_batch_sizes %}
+  preferred_batch_size: [{{ preferred_batch_sizes | join(', ') }}]
+{% endif %}
+  max_queue_delay_microseconds: {{ max_queue_delay_microseconds }}
 }

--- a/grammared_language/triton/triton_transformers_model.py
+++ b/grammared_language/triton/triton_transformers_model.py
@@ -66,9 +66,14 @@ def load_pipeline_from_config(model_config:BaseModelConfig, task="text2text-gene
             provider = "CPUExecutionProvider"
             if 'cuda' in kwargs['device'].lower():
                 provider = 'CUDAExecutionProvider'
+            # rayliuca/coedit-large-onnx ships separate decoder and
+            # decoder-with-past ONNX files, not decoder_model_merged.onnx.
+            # Explicitly disable Optimum's merged-decoder lookup so this
+            # model layout loads on the supported CUDA runtime.
             model = ORTModelClass.from_pretrained(
                 hf_model,
-                provider=provider
+                provider=provider,
+                use_merged=False,
             )
             logger.warning(f"model_config.model_config: {model_config.model_config}")
             logger.warning(f"kwargs: {kwargs}")

--- a/grammared_language/triton/triton_transformers_model.py
+++ b/grammared_language/triton/triton_transformers_model.py
@@ -41,6 +41,19 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 DEFAULT_MODEL_BACKEND = "transformers"
+GENERATION_KWARG_NAMES = ("temperature", "max_length", "num_beams", "do_sample")
+
+
+def generation_kwargs_from_config(model_inference_config):
+    """Return only supported Hugging Face generation kwargs from configuration."""
+    values = model_inference_config.model_dump()
+    return {
+        name: values[name]
+        for name in GENERATION_KWARG_NAMES
+        if name in values and values[name] is not None
+    }
+
+
 def load_pipeline_from_config(model_config:BaseModelConfig, task="text2text-generation", backend:str="transformers", fallback:bool=True, **kwargs):
     """Load a HuggingFace model based on the provided configuration.
 
@@ -114,10 +127,10 @@ class TritonTransformersPythonModel:
         )
         self.grammared_language_model_config = get_model_config(self.model_config.get("name", "transfomers_model"), self.grammared_language_model_config)
 
-        default_max_gen_length = 30
-        self.max_output_length = default_max_gen_length
-        if hasattr(self.grammared_language_model_config.model_inference_config, 'max_length'):
-            self.max_output_length = self.grammared_language_model_config.model_inference_config.max_length
+        self.generation_kwargs = generation_kwargs_from_config(
+            self.grammared_language_model_config.model_inference_config
+        )
+        self.generation_kwargs.setdefault("max_length", 30)
         # Check for user-specified model name in model config parameters
         hf_model = self.model_params.get("pretrained_model_name_or_path", {}).get(
             "string_value", self.DEFAULT_HF_MODEL
@@ -181,7 +194,7 @@ class TritonTransformersPythonModel:
         """Generate text for a batch of prompts."""
         sequences = self.pipeline(
             prompts,
-            max_length=self.max_output_length,
+            **self.generation_kwargs,
         )
         all_texts = [seq["generated_text"] for seq in sequences]
         logger.warning(f"Generated: {all_texts}")

--- a/grammared_language/utils/config_parser.py
+++ b/grammared_language/utils/config_parser.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Any, Optional, List, Literal, Union
 import yaml
 import os
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Prevent circular dependancy 
 if TYPE_CHECKING:
@@ -22,7 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 class ServingConfig(BaseModel):
-    """Configuration for model serving settings."""
+    """Configuration for model serving settings.
+
+    Triton scheduler batching is intentionally configured here, separately from
+    model_init_config/model_inference_config.  Those model settings (including
+    a GECToR prediction ``batch_size``) do not change Triton's request
+    scheduler, and client concurrency does not change either of them.
+    """
     
     model_config = ConfigDict(extra='allow')
     
@@ -33,6 +39,31 @@ class ServingConfig(BaseModel):
     pretrained_model_name_or_path: Optional[str] = None
     backend: Optional[str] = "transformers" # "transformers", "ort"
     device: Optional[str] = "auto"  # "cpu", "cuda", or "auto"
+    max_batch_size: int = Field(default=8, ge=1)
+    preferred_batch_sizes: Optional[List[int]] = Field(
+        default_factory=lambda: [1, 2, 4, 8]
+    )
+    # None selects the legacy default for the specific model type in
+    # TritonRepoBuilder (350 us for GECToR, 750 us for CoEdIT, 100 us for the
+    # classifier), preserving generated configs from before this field existed.
+    max_queue_delay_microseconds: Optional[int] = Field(default=None, ge=0)
+
+    @field_validator("preferred_batch_sizes")
+    @classmethod
+    def validate_preferred_batch_sizes(cls, value: Optional[List[int]]):
+        if value is not None and any(size < 1 for size in value):
+            raise ValueError("preferred_batch_sizes must contain positive integers")
+        if value is not None and len(set(value)) != len(value):
+            raise ValueError("preferred_batch_sizes must not contain duplicates")
+        return value
+
+    @model_validator(mode="after")
+    def validate_preferred_batch_sizes_do_not_exceed_max(self):
+        if self.preferred_batch_sizes and any(
+            size > self.max_batch_size for size in self.preferred_batch_sizes
+        ):
+            raise ValueError("preferred_batch_sizes cannot exceed max_batch_size")
+        return self
     
 
 class ModelInitConfig(BaseModel):
@@ -50,6 +81,14 @@ class ModelInferenceConfig(BaseModel):
     # temperature: Optional[float] = None
     # max_length: Optional[int] = None
     # num_beams: Optional[int] = None
+
+
+class GectorInferenceConfig(ModelInferenceConfig):
+    """Per-prediction GECToR settings, independent of Triton scheduling."""
+
+    # This retains GectorClient's historical default.  It controls how its
+    # predict helper chunks a caller-supplied list, not max_batch_size in Triton.
+    batch_size: int = Field(default=2, ge=1)
 
 
 class GrammaredConfig(BaseModel):
@@ -83,6 +122,9 @@ class GectorConfig(BaseModelConfig):
     """Configuration for GECToR models."""
     
     type: Literal['gector'] = 'gector'
+    model_inference_config: GectorInferenceConfig = Field(
+        default_factory=GectorInferenceConfig
+    )
 
 
 class GrammaredClassifierConfig(BaseModelConfig):
@@ -273,8 +315,16 @@ def create_client_from_config(
         if isinstance(config, GectorConfig):
             from grammared_language.clients.gector_client import GectorClient
             
-            # GectorClient expects model_id and triton_model_name
-            client_params = vars(config.serving_config)
+            # Scheduler settings are consumed when rendering Triton's config;
+            # GECToR's prediction batch_size comes only from model_inference_config.
+            client_params = config.serving_config.model_dump(
+                exclude={
+                    'max_batch_size',
+                    'preferred_batch_sizes',
+                    'max_queue_delay_microseconds',
+                }
+            )
+            client_params.update(config.model_inference_config.model_dump())
             client_params.update(vars(config.grammared_config) if config.grammared_config else {})
             
             return GectorClient(**client_params)

--- a/grammared_language/utils/config_parser.py
+++ b/grammared_language/utils/config_parser.py
@@ -7,7 +7,7 @@ import yaml
 import os
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-# Prevent circular dependancy 
+# Prevent circular dependancy
 if TYPE_CHECKING:
     from grammared_language.clients.base_client import BaseClient
 
@@ -74,13 +74,24 @@ class ModelInitConfig(BaseModel):
 
 
 class ModelInferenceConfig(BaseModel):
-    """Configuration for model inference settings."""
+    """Validated generation settings shared by text-to-text models.
+
+    ``temperature`` is only accepted with ``do_sample: true`` because Hugging
+    Face ignores it for deterministic generation.
+    """
     
     model_config = ConfigDict(extra='allow')
     
-    # temperature: Optional[float] = None
-    # max_length: Optional[int] = None
-    # num_beams: Optional[int] = None
+    temperature: Optional[float] = Field(default=None, gt=0)
+    max_length: Optional[int] = Field(default=None, ge=1)
+    num_beams: Optional[int] = Field(default=None, ge=1)
+    do_sample: bool = False
+
+    @model_validator(mode="after")
+    def validate_temperature_requires_sampling(self):
+        if self.temperature is not None and not self.do_sample:
+            raise ValueError("temperature requires do_sample=true")
+        return self
 
 
 class GectorInferenceConfig(ModelInferenceConfig):
@@ -114,9 +125,9 @@ class BaseModelConfig(BaseModel):
     
     # Nested config format
     serving_config: ServingConfig
-    model_init_config: Optional[ModelInitConfig] = Field(default=ModelInitConfig(), alias='model_config')
-    model_inference_config: Optional[ModelInferenceConfig] = ModelInferenceConfig()
-    grammared_config: Optional[GrammaredConfig] = GrammaredConfig()
+    model_init_config: ModelInitConfig = Field(default_factory=ModelInitConfig)
+    model_inference_config: ModelInferenceConfig = Field(default_factory=ModelInferenceConfig)
+    grammared_config: GrammaredConfig = Field(default_factory=GrammaredConfig)
 
 class GectorConfig(BaseModelConfig):
     """Configuration for GECToR models."""
@@ -342,7 +353,10 @@ def create_client_from_config(
         elif isinstance(config, CoEditConfig):
             from grammared_language.clients.coedit_client import CoEditClient
             
-            client_params = vars(config.serving_config)
+            client_params = config.serving_config.model_dump()
+            # The repository builder and the client must use the same served
+            # name; the logical YAML key is not a Triton model identifier.
+            client_params["model_name"] = client_params.pop("triton_model_name") or model_name
             client_params.update(vars(config.grammared_config) if config.grammared_config else {})
             
             logger.warning(f"Creating CoEditClient with params: {client_params}")

--- a/grammared_language/utils/config_parser.py
+++ b/grammared_language/utils/config_parser.py
@@ -1,12 +1,15 @@
 """Utilities for parsing model configuration files."""
+from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Literal, Union
+from typing import TYPE_CHECKING, Dict, Any, Optional, List, Literal, Union
 import yaml
 import os
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from grammared_language.clients.base_client import BaseClient
+# Prevent circular dependancy 
+if TYPE_CHECKING:
+    from grammared_language.clients.base_client import BaseClient
 
 DEFAULT_MODEL_CONFIG_PATH = "/default_model_config.yaml"
 MODEL_CONFIG_PATH = "/model_config.yaml"

--- a/model_config.yaml
+++ b/model_config.yaml
@@ -8,6 +8,15 @@ gector_deberta_large:
         triton_model_name: gector_deberta_large
         device: cuda # cpu, cuda, or auto
 
+        # Triton scheduler limits. These are independent of GECToR's
+        # model_inference_config.batch_size and API request concurrency.
+        max_batch_size: 8 # largest single inference batch Triton may execute
+        # Target sizes for Triton's dynamic batcher; use null to omit targets.
+        preferred_batch_sizes: [1, 2, 4, 8]
+        # Maximum time Triton waits to form a dynamic batch, in microseconds.
+        max_queue_delay_microseconds: 350
+
+
 coedit_large:
     type: coedit
     backend: triton
@@ -19,7 +28,16 @@ coedit_large:
         triton_model_name: coedit_large
         backend: ort
         device: cuda # cpu, cuda, or auto
+        # Triton scheduler settings, not the ONNX model batch size.
+        max_batch_size: 8 # largest single inference batch Triton may execute
+        # Target sizes for Triton's dynamic batcher; use null to omit targets.
+        preferred_batch_sizes: [1, 2, 4, 8]
+        
+        # Maximum time Triton waits to form a dynamic batch, in microseconds.
+        max_queue_delay_microseconds: 750
+
     model_init_config:
+        # CoEdIT/ONNX model initialization batch setting; not a Triton limit.
         batch_size: 8
     model_inference_config:
         temperature: 0.8

--- a/model_config.yaml
+++ b/model_config.yaml
@@ -32,7 +32,7 @@ coedit_large:
         max_batch_size: 8 # largest single inference batch Triton may execute
         # Target sizes for Triton's dynamic batcher; use null to omit targets.
         preferred_batch_sizes: [1, 2, 4, 8]
-        
+
         # Maximum time Triton waits to form a dynamic batch, in microseconds.
         max_queue_delay_microseconds: 750
 
@@ -40,6 +40,9 @@ coedit_large:
         # CoEdIT/ONNX model initialization batch setting; not a Triton limit.
         batch_size: 8
     model_inference_config:
+        # - do_sample: false (default): deterministic decoding, typically greedy/beam search. temperature has no effect.
+        # - do_sample: true: introduces controlled variation. Lower temperature (e.g. 0.3) is more conservative; higher (e.g. 0.8–1.0) is more varied.
         temperature: 0.8
+        do_sample: true
     grammared_config:
         prompt_template: "Fix grammatical errors: {{ text }}"

--- a/test_model_config.yaml
+++ b/test_model_config.yaml
@@ -23,7 +23,11 @@ coedit_large:
     model_init_config:
         batch_size: 8
     model_inference_config:
+       # - do_sample: false (default): deterministic decoding, typically greedy/beam search. temperature has no effect.
+       # - do_sample: true: introduces controlled variation. Lower temperature (e.g. 0.3) is more conservative; higher (e.g. 0.8–1.0) is more varied.
         temperature: 0.8
+        do_sample: true
+
     grammared_config:
         prompt_template: "Fix grammatical errors: {{ text }}"
 

--- a/tests/api/test_grpc_server_unit.py
+++ b/tests/api/test_grpc_server_unit.py
@@ -1,0 +1,189 @@
+"""Hermetic regression tests for gRPC batching and client lifecycle."""
+
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+from api.src import grpc_server
+from grammared_language.api.grpc_gen import ml_server_pb2
+from grammared_language.language_tool.output_models import (
+    LanguageToolRemoteResult,
+    Match,
+)
+
+
+def result_for(text):
+    return LanguageToolRemoteResult(
+        language="English",
+        languageCode="en-US",
+        matches=[Match(offset=0, length=1, message=text, shortMessage=text)],
+    )
+
+
+class RecordingClient:
+    def __init__(self, label=""):
+        self.label = label
+        self.calls = []
+        self.closed = False
+
+    def predict_with_merge(self, texts):
+        self.calls.append(texts)
+        if isinstance(texts, str):
+            return result_for(self.label or texts)
+        return [result_for(self.label or text) for text in texts]
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_server_state():
+    with grpc_server.client_condition:
+        grpc_server.correction_multi_client = None
+        grpc_server._client_inflight.clear()
+        grpc_server._model_generation = 0
+    grpc_server.analyze_cache_store.clear()
+    grpc_server.process_cache_store.clear()
+    grpc_server.match_cache_store.clear()
+    grpc_server.match_anylized_cache_store.clear()
+    yield
+
+
+def process_request(*texts):
+    return ml_server_pb2.ProcessRequest(
+        sentences=[ml_server_pb2.AnalyzedSentence(text=text) for text in texts],
+        options=ml_server_pb2.ProcessingOptions(language="en-US"),
+    )
+
+
+def descriptions(response):
+    return [match.matchDescription for match in response.matches]
+
+
+def test_process_batches_unique_misses_and_preserves_order():
+    client = RecordingClient()
+    grpc_server.activate_client(client)
+    grpc_server.process_cache_store.add(
+        grpc_server._model_cache_key(grpc_server._model_generation, "cached"),
+        result_for("cached"),
+    )
+
+    response = grpc_server.ProcessingServerServicer().Process(
+        process_request("cached", "first", "second", "cached", "first"), Mock()
+    )
+
+    assert client.calls == [["first", "second"]]
+    assert descriptions(response) == ["cached", "first", "second", "cached", "first"]
+    cache_key = grpc_server._model_cache_key(grpc_server._model_generation, "first")
+    assert grpc_server.process_cache_store.contains(cache_key)
+
+
+def test_process_uses_cached_entries_without_inference():
+    client = RecordingClient()
+    grpc_server.activate_client(client)
+    key = grpc_server._model_cache_key(grpc_server._model_generation, "cached")
+    grpc_server.process_cache_store.add(key, result_for("cached"))
+
+    response = grpc_server.ProcessingServerServicer().Process(
+        process_request("cached", "cached"), Mock()
+    )
+
+    assert client.calls == []
+    assert descriptions(response) == ["cached", "cached"]
+
+
+def test_concurrent_process_calls_are_not_serialized_by_client_lock():
+    both_calls_started = threading.Barrier(2)
+
+    class BlockingClient(RecordingClient):
+        def predict_with_merge(self, texts):
+            self.calls.append(texts)
+            both_calls_started.wait(timeout=2)
+            return [result_for(text) for text in texts]
+
+    client = BlockingClient()
+    grpc_server.activate_client(client)
+    servicer = grpc_server.ProcessingServerServicer()
+    failures = []
+
+    def process(text):
+        try:
+            servicer.Process(process_request(text), Mock())
+        except Exception as error:  # pragma: no cover - assertion below reports it
+            failures.append(error)
+
+    first = threading.Thread(target=process, args=("first",))
+    second = threading.Thread(target=process, args=("second",))
+    first.start()
+    second.start()
+    first.join(timeout=3)
+    second.join(timeout=3)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert failures == []
+    assert client.calls == [["first"], ["second"]]
+
+
+def test_reload_swaps_client_and_retires_old_client_outside_lock():
+    old_started = threading.Event()
+    allow_old_finish = threading.Event()
+
+    class BlockingOldClient(RecordingClient):
+        def predict_with_merge(self, texts):
+            self.calls.append(texts)
+            old_started.set()
+            assert allow_old_finish.wait(timeout=3)
+            return [result_for(text) for text in texts]
+
+    old_client = BlockingOldClient()
+    new_client = RecordingClient("new")
+    grpc_server.activate_client(old_client)
+    servicer = grpc_server.ProcessingServerServicer()
+    request_thread = threading.Thread(
+        target=lambda: servicer.Process(process_request("old"), Mock())
+    )
+    request_thread.start()
+    assert old_started.wait(timeout=1)
+
+    reload_thread = threading.Thread(target=grpc_server.activate_client, args=(new_client,))
+    reload_thread.start()
+
+    # The old lease keeps retirement waiting, but the newly active client is
+    # available immediately because the lifecycle lock is not held while waiting.
+    response = servicer.Process(process_request("new request"), Mock())
+    assert descriptions(response) == ["new"]
+    assert new_client.calls == [["new request"]]
+    assert not old_client.closed
+
+    allow_old_finish.set()
+    request_thread.join(timeout=3)
+    reload_thread.join(timeout=3)
+    assert not request_thread.is_alive()
+    assert not reload_thread.is_alive()
+    assert old_client.closed
+
+
+def test_reload_invalidates_grammar_result_caches():
+    old_client = RecordingClient("old")
+    new_client = RecordingClient("new")
+    servicer = grpc_server.ProcessingServerServicer()
+    grpc_server.activate_client(old_client)
+
+    assert descriptions(servicer.Process(process_request("same"), Mock())) == ["old"]
+    assert old_client.calls == [["same"]]
+
+    grpc_server.activate_client(new_client)
+    response = servicer.Process(process_request("same"), Mock())
+
+    assert descriptions(response) == ["new"]
+    assert new_client.calls == [["same"]]
+    assert old_client.closed
+
+
+def test_simple_cache_store_clear():
+    cache = grpc_server.SimpleCacheStore()
+    cache.add("key", "value")
+    cache.clear()
+    assert not cache.contains("key")

--- a/tests/clients/test_async_multi_client.py
+++ b/tests/clients/test_async_multi_client.py
@@ -41,6 +41,42 @@ class MockClient(BaseClient):
             )
 
 
+class RecordingBatchClient(MockClient):
+    """Batch mock that records calls and makes each input's matches distinct."""
+
+    def __init__(self, name, offset_base=0):
+        super().__init__(name)
+        self.offset_base = offset_base
+
+    def predict(self, text):
+        if not isinstance(text, list):
+            return super().predict(text)
+        self.calls = getattr(self, "calls", []) + [text]
+        return [
+            LanguageToolRemoteResult(
+                language="English",
+                languageCode="en-US",
+                matches=[
+                    Match(
+                        message=f"{self.name}-{index}",
+                        shortMessage=self.name,
+                        offset=self.offset_base + index,
+                        length=1,
+                        suggestions=[self.name],
+                    )
+                ],
+            )
+            for index, _ in enumerate(text)
+        ]
+
+
+class ShortBatchClient(BaseClient):
+    """Returns an invalid short batch to exercise BaseClient validation."""
+
+    def _predict(self, text):
+        return ["first", "second"]
+
+
 class TestAsyncMultiClient:
     """Test suite for AsyncMultiClient."""
     
@@ -251,6 +287,67 @@ class TestAsyncMultiClient:
         # Each text should have results from both clients
         for text_results in results:
             assert len(text_results) == 2
+
+    @pytest.mark.asyncio
+    async def test_predict_batch_with_merge_batches_each_client_once_and_merges(self):
+        texts = ["first", "second", "third"]
+        client1 = RecordingBatchClient("gector", offset_base=5)
+        client2 = RecordingBatchClient("coedit", offset_base=1)
+        async_client = AsyncMultiClient(clients=[client1, client2])
+
+        results = await async_client._predict_batch_with_merge_async(texts)
+
+        assert client1.calls == [texts]
+        assert client2.calls == [texts]
+        assert len(results) == 3
+        for index, result in enumerate(results):
+            assert [match.message for match in result.matches] == [
+                f"coedit-{index}",
+                f"gector-{index}",
+            ]
+            assert [match.offset for match in result.matches] == [1 + index, 5 + index]
+
+    @pytest.mark.asyncio
+    async def test_predict_batch_with_merge_keeps_alignment_when_client_fails(self):
+        texts = ["first", "second", "third"]
+        client = RecordingBatchClient("gector")
+        failed_client = MockClient("coedit")
+        failed_client.predict = Mock(side_effect=ValueError("unavailable"))
+        async_client = AsyncMultiClient(clients=[client, failed_client])
+
+        results = await async_client._predict_batch_with_merge_async(texts)
+
+        assert client.calls == [texts]
+        assert len(results) == 3
+        assert [result.matches[0].message for result in results] == [
+            "gector-0",
+            "gector-1",
+            "gector-2",
+        ]
+
+    def test_predict_batch_rejects_short_model_output(self):
+        client = ShortBatchClient(rule_id="short")
+
+        with pytest.raises(
+            RuntimeError,
+            match="Batch prediction returned 2 outputs for 3 inputs",
+        ):
+            client.predict(["first", "second", "third"])
+
+    @pytest.mark.asyncio
+    async def test_predict_batch_failure_adds_aligned_empty_client_results(self):
+        texts = ["first", "second", "third"]
+        successful_client = RecordingBatchClient("gector")
+        failed_client = MockClient("coedit")
+        failed_client.predict = Mock(side_effect=RuntimeError("unavailable"))
+        async_client = AsyncMultiClient(clients=[successful_client, failed_client])
+
+        results = await async_client._predict_batch_async(texts)
+
+        assert successful_client.calls == [texts]
+        assert len(results) == 3
+        assert all(len(client_results) == 2 for client_results in results)
+        assert all(client_results[1].matches == [] for client_results in results)
     
     @pytest.mark.asyncio
     async def test_concurrent_requests_same_text(self):

--- a/tests/clients/test_base_client_cache.py
+++ b/tests/clients/test_base_client_cache.py
@@ -1,0 +1,104 @@
+from grammared_language.clients.base_client import BaseClient
+from grammared_language.language_tool.output_models import LanguageToolRemoteResult
+
+
+class RecordingClient(BaseClient):
+    def __init__(self):
+        super().__init__()
+        self.predict_calls = []
+
+    def _predict(self, text):
+        self.predict_calls.append(text)
+        if isinstance(text, list):
+            return [f"corrected: {value}" for value in text]
+        return f"corrected: {text}"
+
+    def _pred_postprocess(self, original, pred, **kwargs):
+        return LanguageToolRemoteResult(
+            language="English", languageCode="en-US", matches=[]
+        )
+
+
+def test_scalar_prediction_uses_sentence_cache():
+    client = RecordingClient()
+
+    first = client.predict("A")
+    second = client.predict("A")
+
+    assert client.predict_calls == ["A"]
+    assert first is second
+
+
+def test_sentence_cache_uses_lru_eviction(monkeypatch):
+    monkeypatch.setenv("GRAMMARED_LANGUAGE__GRPC_SERVER_CACHE_SIZE", "2")
+    client = RecordingClient()
+
+    client.predict("A")
+    client.predict("B")
+    client.predict("A")  # Refresh A so B becomes least recently used.
+    client.predict("C")
+    client.predict("B")
+
+    assert client.predict_calls == ["A", "B", "C", "B"]
+
+
+def test_fully_cached_batch_does_not_infer():
+    client = RecordingClient()
+    for text in ["A", "B", "C"]:
+        client.predict(text)
+    client.predict_calls.clear()
+
+    results = client.predict(["A", "B", "C"])
+
+    assert len(results) == 3
+    assert client.predict_calls == []
+
+
+def test_partially_cached_batch_sends_only_uncached_sentences_once():
+    client = RecordingClient()
+    client.predict("A")
+    client.predict("C")
+    client.predict_calls.clear()
+
+    results = client.predict(["A", "B", "C", "D"])
+
+    assert len(results) == 4
+    assert client.predict_calls == [["B", "D"]]
+
+
+def test_cold_batch_is_sent_as_one_model_batch():
+    client = RecordingClient()
+
+    results = client.predict(["A", "B", "C"])
+
+    assert len(results) == 3
+    assert client.predict_calls == [["A", "B", "C"]]
+
+
+def test_batch_deduplicates_uncached_sentences_and_preserves_order():
+    client = RecordingClient()
+
+    results = client.predict(["A", "B", "A", "C", "B"])
+
+    assert client.predict_calls == [["A", "B", "C"]]
+    assert results[0] is results[2]
+    assert results[1] is results[4]
+    assert len(results) == 5
+
+
+def test_batch_cardinality_mismatch_raises_before_caching():
+    class ShortBatchClient(RecordingClient):
+        def _predict(self, text):
+            self.predict_calls.append(text)
+            return ["only one"]
+
+    client = ShortBatchClient()
+
+    try:
+        client.predict(["A", "B"])
+    except RuntimeError as error:
+        assert str(error) == "Batch prediction returned 1 outputs for 2 inputs"
+    else:
+        raise AssertionError("Expected a batch cardinality failure")
+
+    assert client.cache_stats()["size"] == 0

--- a/tests/clients/test_gector_client.py
+++ b/tests/clients/test_gector_client.py
@@ -66,7 +66,8 @@ class TestGectorClientUnit:
         # Create client
         client = GectorClient(
             pretrained_model_name_or_path="test-model",
-            verb_dict_path="test-vocab.txt"
+            verb_dict_path="test-vocab.txt",
+            auto_download_official_vocab=False,
         )
         
         # Verify initialization
@@ -99,7 +100,8 @@ class TestGectorClientUnit:
         client = GectorClient(
             pretrained_model_name_or_path="test-model",
             triton_model_name=MODEL_NAME,
-            verb_dict_path="test-vocab.txt"
+            verb_dict_path="test-vocab.txt",
+            auto_download_official_vocab=False,
         )
         
         # Verify Triton model was used (with triton_url parameter)
@@ -126,7 +128,11 @@ class TestGectorClientUnit:
         mock_predict.return_value = ["This is corrected text."]
         
         # Create client and test predict
-        client = GectorClient(pretrained_model_name_or_path="test-model", verb_dict_path="test-vocab.txt")
+        client = GectorClient(
+            pretrained_model_name_or_path="test-model",
+            verb_dict_path="test-vocab.txt",
+            auto_download_official_vocab=False,
+        )
         result = client._predict("This is test text")
         
         # Verify predict was called
@@ -149,7 +155,11 @@ class TestGectorClientUnit:
         mock_predict.return_value = ["This is the corrected text."]
         
         # Create client
-        client = GectorClient(pretrained_model_name_or_path="test-model", verb_dict_path="test-vocab.txt")
+        client = GectorClient(
+            pretrained_model_name_or_path="test-model",
+            verb_dict_path="test-vocab.txt",
+            auto_download_official_vocab=False,
+        )
         
         # Test full predict
         result = client.predict("This is test text")
@@ -177,7 +187,11 @@ class TestGectorClientUnit:
         mock_predict.return_value = ["Corrected text."]
         
         # Create client and test callable
-        client = GectorClient(pretrained_model_name_or_path="test-model", verb_dict_path="test-vocab.txt")
+        client = GectorClient(
+            pretrained_model_name_or_path="test-model",
+            verb_dict_path="test-vocab.txt",
+            auto_download_official_vocab=False,
+        )
         result = client("Test text")
         
         # Verify result

--- a/tests/clients/test_text2text_base_client.py
+++ b/tests/clients/test_text2text_base_client.py
@@ -141,6 +141,45 @@ class TestText2TextBaseClient:
         
         # Should return original text if no output
         assert result == input_text
+
+    @patch('grammared_language.clients.text2text_base_client.grpcclient')
+    def test_predict_batch_uses_column_tensor_and_preserves_output_order(self, mock_grpcclient):
+        """A batch must match Triton's [batch_size, 1] text-input contract."""
+        mock_client = Mock()
+        mock_grpcclient.InferenceServerClient = Mock(return_value=mock_client)
+        mock_grpcclient.InferInput = Mock()
+        mock_grpcclient.InferRequestedOutput = Mock()
+        mock_response = Mock()
+        mock_response.as_numpy.return_value = np.array(
+            [[b"first output"], [b"second output"], [b"third output"]],
+            dtype=object,
+        )
+        mock_client.infer.return_value = mock_response
+
+        client = Text2TextBaseClient(model_name="coedit_large")
+        result = client._predict(["first input", "second input", "third input"])
+
+        assert result == ["first output", "second output", "third output"]
+        infer_input_args = mock_grpcclient.InferInput.call_args.args
+        assert infer_input_args[1] == [3, 1]
+
+    @patch('grammared_language.clients.text2text_base_client.grpcclient')
+    def test_predict_batch_full_flow_does_not_cache_unhashable_list(self, mock_grpcclient):
+        mock_client = Mock()
+        mock_grpcclient.InferenceServerClient = Mock(return_value=mock_client)
+        mock_grpcclient.InferInput = Mock()
+        mock_grpcclient.InferRequestedOutput = Mock()
+        mock_response = Mock()
+        mock_response.as_numpy.return_value = np.array(
+            [[b"First."], [b"Second."], [b"Third."]], dtype=object
+        )
+        mock_client.infer.return_value = mock_response
+
+        client = Text2TextBaseClient(model_name="coedit_large")
+        results = client.predict(["First.", "Second.", "Third."])
+
+        assert len(results) == 3
+        assert mock_client.infer.call_count == 1
     
     @patch('grammared_language.clients.text2text_base_client.grpcclient')
     def test_predict_full_flow(self, mock_grpcclient):

--- a/tests/triton/test_triton_repo_reconciliation.py
+++ b/tests/triton/test_triton_repo_reconciliation.py
@@ -1,0 +1,52 @@
+from grammared_language.triton.builder.repo_builder import TritonRepoBuilder
+from grammared_language.utils.config_parser import ModelsConfig
+
+
+def coedit_config(name="served_model", max_batch_size=8):
+    return ModelsConfig.from_dict({
+        "logical_model": {
+            "type": "coedit",
+            "serving_config": {
+                "triton_model_name": name,
+                "pretrained_model_name_or_path": "example/model",
+                "max_batch_size": max_batch_size,
+                "preferred_batch_sizes": [1, max_batch_size],
+                "max_queue_delay_microseconds": 123,
+            },
+        },
+    })
+
+
+def test_reconciliation_updates_batching_name_removals_and_preserves_unchanged(tmp_path):
+    builder = TritonRepoBuilder()
+
+    builder.reconcile_model_repo(str(tmp_path), coedit_config(max_batch_size=8))
+    original = tmp_path / "served_model" / "config.pbtxt"
+    initial_contents = original.read_text()
+    initial_mtime = original.stat().st_mtime_ns
+    assert "max_batch_size: 8" in initial_contents
+
+    builder.reconcile_model_repo(str(tmp_path), coedit_config(max_batch_size=16))
+    assert "max_batch_size: 16" in original.read_text()
+
+    builder.reconcile_model_repo(str(tmp_path), coedit_config(name="renamed_model", max_batch_size=16))
+    assert not (tmp_path / "served_model").exists()
+    renamed = tmp_path / "renamed_model" / "config.pbtxt"
+    assert renamed.is_file()
+
+    unchanged_mtime = renamed.stat().st_mtime_ns
+    builder.reconcile_model_repo(str(tmp_path), coedit_config(name="renamed_model", max_batch_size=16))
+    assert renamed.stat().st_mtime_ns == unchanged_mtime
+
+    builder.reconcile_model_repo(str(tmp_path), ModelsConfig.from_dict({}))
+    assert not (tmp_path / "renamed_model").exists()
+
+
+def test_reconciliation_does_not_delete_unmanaged_directories(tmp_path):
+    user_model = tmp_path / "user_model"
+    user_model.mkdir()
+    (user_model / "keep.txt").write_text("user content")
+
+    TritonRepoBuilder().reconcile_model_repo(str(tmp_path), ModelsConfig.from_dict({}))
+
+    assert (user_model / "keep.txt").read_text() == "user content"

--- a/tests/triton/test_triton_transformers_model.py
+++ b/tests/triton/test_triton_transformers_model.py
@@ -1,0 +1,60 @@
+import sys
+from unittest.mock import MagicMock
+
+
+def test_generation_config_reaches_pipeline(monkeypatch):
+    # The Triton backend utilities are supplied by Triton at runtime, so stub
+    # them before importing the model module in this unit test.
+    monkeypatch.setitem(sys.modules, "triton_python_backend_utils", MagicMock())
+    monkeypatch.setitem(sys.modules, "torch", MagicMock())
+    monkeypatch.setitem(sys.modules, "transformers", MagicMock())
+    from grammared_language.triton.triton_transformers_model import (
+        TritonTransformersPythonModel,
+    )
+    from grammared_language.utils.config_parser import CoEditConfig
+
+    model = TritonTransformersPythonModel()
+    model.grammared_language_model_config = CoEditConfig(
+        type="coedit",
+        serving_config={},
+        model_inference_config={
+            "temperature": 0.8,
+            "do_sample": True,
+            "num_beams": 2,
+            "max_length": 42,
+            "unrelated_setting": "ignored",
+        },
+    )
+    from grammared_language.triton.triton_transformers_model import generation_kwargs_from_config
+    model.generation_kwargs = generation_kwargs_from_config(
+        model.grammared_language_model_config.model_inference_config
+    )
+    model.pipeline = MagicMock(return_value=[{"generated_text": "fixed"}])
+
+    # The mocked backend response classes keep this focused on the pipeline
+    # invocation performed by generate_batch.
+    model.generate_batch(["Fix: text"])
+
+    model.pipeline.assert_called_once_with(
+        ["Fix: text"], temperature=0.8, do_sample=True, num_beams=2, max_length=42
+    )
+
+
+def test_model_init_config_is_passed_to_pipeline(monkeypatch):
+    monkeypatch.setitem(sys.modules, "triton_python_backend_utils", MagicMock())
+    monkeypatch.setitem(sys.modules, "torch", MagicMock())
+    monkeypatch.setitem(sys.modules, "transformers", MagicMock())
+    from grammared_language.triton import triton_transformers_model as module
+    from grammared_language.utils.config_parser import CoEditConfig
+
+    pipeline = MagicMock()
+    monkeypatch.setattr(module.transformers, "pipeline", pipeline)
+    config = CoEditConfig(
+        type="coedit",
+        serving_config={"pretrained_model_name_or_path": "example/model"},
+        model_init_config={"batch_size": 8},
+    )
+
+    module.load_pipeline_from_config(config, device="cpu")
+
+    assert pipeline.call_args.kwargs["batch_size"] == 8

--- a/tests/utils/test_config_parser.py
+++ b/tests/utils/test_config_parser.py
@@ -90,6 +90,25 @@ class TestCreateClientFromConfig:
         call_kwargs = mock_gector.call_args[1]
         assert call_kwargs['pretrained_model_name_or_path'] == 'test-model'
         assert call_kwargs['triton_model_name'] == 'test_triton_model'
+
+    @patch('grammared_language.clients.gector_client.GectorClient')
+    def test_gector_prediction_batch_size_comes_from_inference_config(self, mock_gector):
+        """GECToR helper chunking is not coupled to Triton scheduler batching."""
+        config = {
+            'type': 'gector',
+            'serving_config': {
+                'pretrained_model_name_or_path': 'test-model',
+                'triton_model_name': 'test_triton_model',
+                'max_batch_size': 32,
+            },
+            'model_inference_config': {'batch_size': 3},
+        }
+
+        create_client_from_config('test_model', config)
+
+        call_kwargs = mock_gector.call_args[1]
+        assert call_kwargs['batch_size'] == 3
+        assert 'max_batch_size' not in call_kwargs
     
     @patch('grammared_language.clients.grammar_classification_client.GrammarClassificationClient')
     def test_create_grammared_classifier_client(self, mock_classifier):

--- a/tests/utils/test_config_parser.py
+++ b/tests/utils/test_config_parser.py
@@ -338,12 +338,13 @@ class TestNestedConfigStructure:
                 'backend': 'ort',
                 'device': 'cpu'
             },
-            'model_config': {
+            'model_init_config': {
                 'load_in_4bit': False
             },
             'model_inference_config': {
                 'temperature': 0.8,
-                'max_length': 512
+                'max_length': 512,
+                'do_sample': True,
             },
             'grammared_config': {
                 'prompt_template': 'Fix grammatical errors: {{ text }}'
@@ -358,7 +359,22 @@ class TestNestedConfigStructure:
         assert config.serving_config.triton_port == 8001
         assert config.serving_config.triton_model_name == 'coedit'
         assert config.model_inference_config.temperature == 0.8
+        assert config.model_init_config.load_in_4bit is False
         assert config.grammared_config.prompt_template == 'Fix grammatical errors: {{ text }}'
+
+    @patch('grammared_language.clients.coedit_client.CoEditClient')
+    def test_coedit_uses_served_triton_name_not_logical_name(self, mock_coedit):
+        config = {
+            'type': 'coedit',
+            'serving_config': {
+                'pretrained_model_name_or_path': 'test-model',
+                'triton_model_name': 'actual_triton_name',
+            },
+        }
+
+        create_client_from_config('my_coedit', config)
+
+        assert mock_coedit.call_args.kwargs['model_name'] == 'actual_triton_name'
     
     
     def test_config_requires_serving_config(self):


### PR DESCRIPTION
## Summary

Improve the gRPC execution path so model inference is no longer serialized by the global client lock and `Process()` can take advantage of the batching already supported by `AsyncMultiClient` and Triton.

This addresses the remaining gRPC-side batching, concurrency, reload lifecycle, and stale-cache issues.

## Changes

* Batch unique cache misses from `Process()` into a single `predict_with_merge(...)` call instead of performing sentence-by-sentence inference.
* Preserve input ordering and reuse results for duplicate sentences.
* Replace inference-wide `client_lock` usage with short-lived client leases.
* Allow concurrent gRPC requests to perform inference without being serialized by the client lifecycle lock.
* Atomically swap newly warmed clients during reload.
* Track in-flight users of old clients and close them only after their active requests complete.
* Remove the previous fixed five-second reload delay.
* Invalidate model-dependent result caches when a new model generation becomes active.
* Qualify grammar cache entries by model generation so an old in-flight request cannot repopulate a result visible to the newly activated model.
* Add a thread-safe `clear()` operation to `SimpleCacheStore`.

## Motivation

The model/Triton path already supports batched inference, but the gRPC server was limiting its effectiveness.

`Process()` previously sent cache misses through inference one sentence at a time, while `client_lock` was held for the complete inference call across `Process`, `Match`, and `MatchAnalyzed`.

That effectively serialized otherwise independent gRPC workers before requests reached Triton, reducing opportunities for dynamic batching.

Reload also held the same lock during a fixed five-second grace period, temporarily blocking inference.

This change limits synchronization to client lifecycle operations while allowing model execution to proceed concurrently.

## Client lifecycle

Requests obtain a lease on the currently active `AsyncMultiClient`.

A reload:

1. initializes and warms the replacement client;
2. atomically swaps the active client reference;
3. advances the model generation and invalidates model-result caches;
4. immediately allows new requests to use the replacement client; and
5. waits for existing leases on the old client to complete before closing it.

This removes the arbitrary retirement delay while ensuring an old client is never closed while a request is still using it.

## Cache safety

Model-result cache keys now include the active model generation.

This ensures that a request which started before a reload cannot finish afterwards and accidentally make its old-model result visible to requests using the new model.

The analysis cache is intentionally retained because it is independent of grammar-model inference.
